### PR TITLE
Add team member manager/mentor relationships

### DIFF
--- a/database/migrations/20190429152517_add_team_member_relationships.js
+++ b/database/migrations/20190429152517_add_team_member_relationships.js
@@ -1,0 +1,22 @@
+
+exports.up = function(knex, Promise) {
+  return knex.schema.table('team_members', tbl => {
+    tbl.integer('manager')
+       .references('id')
+       .inTable('team_members')
+       .onDelete('CASCADE')
+       .onUpdate('CASCADE')
+    tbl.integer('mentor')
+       .references('id')
+       .inTable('team_members')
+       .onDelete('CASCADE')
+       .onUpdate('CASCADE')
+  })
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.table('team_members', tbl => {
+    tbl.dropColumn('manager')
+    tbl.dropColumn('mentor')
+  })
+};


### PR DESCRIPTION
# Description

As part of our MVP requirements, we need to be able to [specify that a team member's organizational relationships](https://trello.com/c/MKzR7wg0). As an additional need, our stakeholder also asked that these relationships be allowed to be cyclical (i.e. Alice can be listed as Bob's manager while Bob is listed as Alice's manager).

This PR adds a new migration to our database that will enable us to specify any existing team member as either a `manager` or a `mentor` for a given team member. We'll do this by specifying the `team_member.id` as the value for the manager/mentor column, and then when we query the database for a given user, we'll join the table on itself to display the manager/mentor, should they exist. 

An example of what this raw SQL query would look like is this:

```sql
SELECT concat(tm1.first_name, ' ', tm1.last_name) "Name", tm2.first_name "Manager", tm3.first_name "Mentor"
FROM team_members tm1
LEFT OUTER JOIN team_members tm2 ON tm2.id = tm1.manager
LEFT OUTER JOIN team_members tm3 ON tm3.id = tm1.mentor
WHERE tm1.id = 1;
```

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

I've added data to the database and verified that it will return the team members, their manager, and their mentors as we expect.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
