### PR TITLE
:card_file_box: Remove MS Teams columns from users table

### DIFF
--- a/database/migrations/20190502112157_remove_msteams.js
+++ b/database/migrations/20190502112157_remove_msteams.js
@@ -1,0 +1,16 @@
+
+exports.up = function(knex, Promise) {
+  return knex.schema.table('users', tbl => {
+    tbl.dropColumn('ms_auth_token')
+    tbl.dropColumn('ms_refresh_token')
+    tbl.dropColumn('ms_token_expiration')
+  })
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.table('users', tbl => {
+    tbl.text('ms_auth_token')
+    tbl.text('ms_refresh_token')
+    tbl.datetime('ms_token_expiration')
+  })
+};


### PR DESCRIPTION
# Description

After yesterdays decision to re-scope v2 and remove MS Teams as an MVP requirement, we need to drop the ms_teams auth token columns from our `users` table. This PR does just that and nothing else. 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

I've run the migrations against Postgres locally and they work as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
