### PR TITLE
Add Data Model for Responses

### DIFF
--- a/database/Helpers/response-model.js
+++ b/database/Helpers/response-model.js
@@ -1,0 +1,53 @@
+const db = require("../dbConfig.js");
+
+module.exports = {
+  add,
+  find,
+  remove,
+}
+/**
+ * Takes a new response object and adds it to the database.
+ * 
+ * Returns a Promise which resolves to the newly created response object, 
+ * including its ID.
+ * 
+ * @param  {Object} response
+ */
+function add(response) {
+  return db('responses')
+    .insert(response, ['*'])
+}
+
+/**
+ * Returns a Promise which, when resolved, contains either an array of 
+ * responses based on the thread they're apart of or an individual response 
+ * based on its ID (which is a UUID). 
+ * 
+ * You should only provide the argument for the item(s) you want returned, 
+ * setting the other to null or _
+ * 
+ * @param  {String} responding_to
+ * @param  {String} id
+ */
+function find(responding_to, id) {
+  if (!responding_to && !id) { 
+    throw Error('You must specify either a response ID or a thread ID')
+  }
+
+  if (responding_to) {
+    return db('responses').where({ responding_to });
+  }
+
+  return db('responses').where({ id }).first();
+}
+/**
+ * Takes a response's ID (which is a UUID) and deletes it from the database,
+ * returns a Promise that resolves with the number of records deleted (if any). 
+ * 
+ * @param  {String} id
+ */
+function remove(id) {
+  return db('responses')
+    .where({ id })
+    .del()
+}

--- a/database/migrations/20190502173932_add_responses_table.js
+++ b/database/migrations/20190502173932_add_responses_table.js
@@ -4,7 +4,7 @@ exports.up = function(knex, Promise) {
 
 	return knex.schema
 		.table('messages', tbl => {
-			tbl.text('message_id').unique();
+			tbl.text('thread_id').unique();
 		})
 		.createTable('responses', tbl => {
 			tbl.uuid('id')
@@ -14,7 +14,7 @@ exports.up = function(knex, Promise) {
 			tbl.text('response_text').notNullable();
 			tbl.text('response_method').notNullable();
 			tbl.text('responding_to')
-				.references('message_id')
+				.references('thread_id')
 				.inTable('messages')
 				.onDelete('CASCADE')
 				.onUpdate('CASCADE')
@@ -29,6 +29,6 @@ exports.down = function(knex, Promise) {
 	return knex.schema
     .dropTableIfExists('responses')
     .table('messages', tbl => {
-			tbl.dropColumn('twilio_id');
+			tbl.dropColumn('thread_id');
 		})
 };

--- a/database/migrations/20190502173932_add_responses_table.js
+++ b/database/migrations/20190502173932_add_responses_table.js
@@ -1,0 +1,34 @@
+exports.up = function(knex, Promise) {
+  // Enable PostgreSQL's built in UUID extension
+  knex.raw('create extension if not exists "uuid_ossp"')
+
+	return knex.schema
+		.table('messages', tbl => {
+			tbl.text('message_id').unique();
+		})
+		.createTable('responses', tbl => {
+			tbl.uuid('id')
+				.primary()
+        .notNullable()
+        .defaultTo(knex.raw('uuid_generate_v4()'))
+			tbl.text('response_text').notNullable();
+			tbl.text('response_method').notNullable();
+			tbl.text('responding_to')
+				.references('message_id')
+				.inTable('messages')
+				.onDelete('CASCADE')
+				.onUpdate('CASCADE')
+				.notNullable();
+		});
+};
+
+exports.down = function(knex, Promise) {
+  // Drop the enabled UUID extension
+  knex.raw('drop extension if exists "uuid-ossp"')
+
+	return knex.schema
+    .dropTableIfExists('responses')
+    .table('messages', tbl => {
+			tbl.dropColumn('twilio_id');
+		})
+};


### PR DESCRIPTION
# Description

With the removal of MS Teams as an MVP feature (see #25), the decision was made to add the enabling of user responses to training messages. This PR adds the data migration necessary to enable message threading and also returning responses from the way we'd need them.

There need to be fairly non-trivial changes to our notification/messages model, our notifications system code, and our backend API endpoints to account for handling threads, but with the feature freeze impending I opted to include those changes in a later PR.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Manually tested on my local machine. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
