### PR TITLE
Fix/find by id validator fix

### DIFF
--- a/controllers/message.js
+++ b/controllers/message.js
@@ -50,7 +50,7 @@ router
       "m.id": id,
       "u.email": user.email
     }).first();
-    message && message.length
+    message
       ? res.status(200).json({ message })
       : res.status(404).json({ message: "That message does not exist" });
   })

--- a/controllers/message.js
+++ b/controllers/message.js
@@ -57,11 +57,17 @@ router
   .delete(async (req, res) => {
     const { id } = req.params;
     const { email } = res.locals.user;
-    const deleted = await Messages.remove({ "m.id": id, "u.email": email });
 
-    deleted
-      ? res.status(200).json({ message: "The message has been deleted." })
-      : res.status(404).json({ error: "That message does not exist." });
+    const message = await Messages.find({
+      "m.id": id,
+      "u.email": email
+    }).first();
+    if (!message) {
+      return res.status(404).json({ message: "That message does not exist" });
+    }
+
+    await Messages.remove({ "m.id": id });
+    res.status(200).json({ message: "The message has been deleted." });
   });
 
 module.exports = router;

--- a/controllers/notification.js
+++ b/controllers/notification.js
@@ -50,7 +50,7 @@ router.route("/:id").get(async (req, res) => {
     "n.id": id,
     "u.email": email
   }).first();
-  notification && notification.length
+  notification
     ? res.status(200).json({ notification })
     : res.status(404).json({ message: "That notification does not exist." });
 });


### PR DESCRIPTION
# Description

Remove check for message.length and notification.length when finding either resource by id since .first() method had been applied and ensured an object was being checked instead of an array. Also performs find(m.id) query before deletion in DELETE messages/:id since knex does not support deletions on joined tables, and we wanted to avoid a messy raw query.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
-
## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

locally in Postman

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
