### PR TITLE
Allow the client to get only assigned Team Members

### DIFF
--- a/helpers/arrayFlat.js
+++ b/helpers/arrayFlat.js
@@ -1,0 +1,9 @@
+function arrayFlat(arr) {
+  return arr.reduce(
+    (acc, val) =>
+      Array.isArray(val) ? acc.concat(arrayFlat(val)) : acc.concat(val),
+    []
+  );
+}
+
+module.exports = arrayFlat


### PR DESCRIPTION
# Description

The front end was having to do a kludgy fix to get the list of assigned team members excluding the managers/mentors. This only returns an array of notifications associated with a training series that are meant for a team member, and it includes that team members' data.

In order to return a useful data structure with the above changes, this fix also includes a new helper function for flattening arrays recursively.

This is because `Array.prototype.flat` isn't supported in the current LTS version of Node.js (10.15.3), though it is introduced in Node.js 11. Future devs on this project should delete my array flattener and just chain `.flat(Infinity)` on to my Promise.all call to make this a bit simpler.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Tested manually with HTTPie and Insomnia. Will need client update to point to the new route.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
