### PR TITLE
Feat/notification batch deletion

### DIFF
--- a/controllers/teamMember.js
+++ b/controllers/teamMember.js
@@ -97,7 +97,16 @@ router.delete("/:id/unassign/:ts_id", async (req, res) => {
   const totalDeleted = notifsToDelete.map(
     async n => await Notifications.remove({ "n.id": n.id })
   );
-  res.status(200).json(totalDeleted.length);
+  totalDeleted.length
+    ? res
+        .status(200)
+        .json({ message: `${totalDeleted.length} resource(s) deleted.` })
+    : res
+        .status(404)
+        .json({
+          message:
+            "This Team Member doesn't have any notifications for that Training Series."
+        });
 });
 
 module.exports = router;


### PR DESCRIPTION
# Description

Created endpoint for batch deletion of all notifications produced by a team member being assigned to a training series, provided the member and series ids. Will be used in FE by myself when creating a button to "unassign" an assigned team member from a series. Props go to @nickcannariato for the majority of the logic as he had something similar written for retrieving a list of notifications for a training series.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Locally in Postman, results seen in browser.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
