### PR TITLE
:art: unassign endpoint returns filterable data

### DIFF
--- a/controllers/teamMember.js
+++ b/controllers/teamMember.js
@@ -93,20 +93,22 @@ router.delete("/:id/unassign/:ts_id", async (req, res) => {
   //flatten array
   const notifsToDelete = arrayFlat(rNotifs);
 
-  //delete each notification and send back total number of deleted items
+  //delete each notification and send back total number of deleted items, along with array of deleted ids for FE to filter through
   const totalDeleted = notifsToDelete.map(
     async n => await Notifications.remove({ "n.id": n.id })
   );
+
   totalDeleted.length
     ? res
         .status(200)
-        .json({ message: `${totalDeleted.length} resource(s) deleted.` })
-    : res
-        .status(404)
         .json({
-          message:
-            "This Team Member doesn't have any notifications for that Training Series."
-        });
+          message: `${totalDeleted.length} resource(s) deleted.`,
+          ids: notifsToDelete.map(n => n.id)
+        })
+    : res.status(404).json({
+        message:
+          "This Team Member doesn't have any notifications for that Training Series."
+      });
 });
 
 module.exports = router;


### PR DESCRIPTION

# Description

Successful deletion in /api/team-members/:id/unassign/:ts_id now returns array of deleted notification ids along with message to allow for cleaner filtering in FE notificationsReducer

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Both in Postman and with updated FE in browser.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
