### PR TITLE
Adds message.id to notifications return to more easily find its pair

### DIFF
--- a/models/db/notifications.js
+++ b/models/db/notifications.js
@@ -15,6 +15,7 @@ function find(filters) {
       "n.is_sent",
       "n.num_attempts",
       "n.thread",
+      "n.message_id",
       "ts.id AS training_series_id",
       "ts.title AS series",
       "tm.id AS team_member_id",


### PR DESCRIPTION
# Description
Adds message IDs to notifications so the frontend can more easily find the message pair to a notification.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?
Manual

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
