### PR TITLE
Fix/notifications return

### DIFF
--- a/models/db/notifications.js
+++ b/models/db/notifications.js
@@ -36,6 +36,8 @@ function find(filters) {
       "n.is_sent",
       "n.num_attempts",
       "n.thread",
+      "n.message_id",
+      "n.for_team_member",
       "ts.id AS training_series_id",
       "ts.title AS series",
       "tm.id AS team_member_id",

--- a/models/db/notifications.js
+++ b/models/db/notifications.js
@@ -37,10 +37,7 @@ function find(filters) {
       "n.num_attempts",
       "n.thread",
       "n.message_id",
-<<<<<<< HEAD
       "n.recipient_id",
-=======
->>>>>>> master
       "ts.id AS training_series_id",
       "ts.title AS series",
       "tm.id AS team_member_id",

--- a/models/db/notifications.js
+++ b/models/db/notifications.js
@@ -37,7 +37,7 @@ function find(filters) {
       "n.num_attempts",
       "n.thread",
       "n.message_id",
-      "n.for_team_member",
+      "n.recipient_id",
       "ts.id AS training_series_id",
       "ts.title AS series",
       "tm.id AS team_member_id",

--- a/models/migrations/20190521124253_add_notif_for_team_member.js
+++ b/models/migrations/20190521124253_add_notif_for_team_member.js
@@ -1,0 +1,14 @@
+exports.up = function(knex, Promise) {
+  return knex.schema.table("notifications", tbl => {
+    tbl
+      .boolean("for_team_member")
+      .notNullable()
+      .defaultTo(true);
+  });
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.table("notifications", tbl => {
+    tbl.dropColumn("for_team_member");
+  });
+};

--- a/models/migrations/20190521131026_add_recipient_id.js
+++ b/models/migrations/20190521131026_add_recipient_id.js
@@ -1,14 +1,11 @@
 exports.up = function(knex, Promise) {
   return knex.schema.table("notifications", tbl => {
-    tbl
-      .boolean("for_team_member")
-      .notNullable()
-      .defaultTo(true);
+    tbl.integer("recipient_id").notNullable();
   });
 };
 
 exports.down = function(knex, Promise) {
   return knex.schema.table("notifications", tbl => {
-    tbl.dropColumn("for_team_member");
+    tbl.dropColumn("recipient_id");
   });
 };

--- a/models/schemas.js
+++ b/models/schemas.js
@@ -108,7 +108,8 @@ const notificationSchema = {
   num_attempts: Joi.number()
     .integer()
     .min(0),
-  thread: Joi.string()
+  thread: Joi.string(),
+  for_team_member: Joi.boolean()
 };
 
 const responseSchema = {

--- a/models/schemas.js
+++ b/models/schemas.js
@@ -109,7 +109,9 @@ const notificationSchema = {
     .integer()
     .min(0),
   thread: Joi.string(),
-  for_team_member: Joi.boolean()
+  recipient_id: Joi.number()
+    .integer()
+    .min(1)
 };
 
 const responseSchema = {


### PR DESCRIPTION
# Description

Adds recipient_id field to notifications for simple manipulation/filtering in the FE when needing to know whether or not a notification is going to the assigned team member or is a copy for their manager/mentor. Migration file added, Joi schema updated, Notifications.find() return updated.

NOTE: WILL REQUIRE RUNNING MIGRATE:LATEST for changes to take effect

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Locally in browser and psql database

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
