### PR TITLE
:bug: Fix broken JS Doc links in the README

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -38,7 +38,7 @@ Valid JWTs are provided by the Auth0 integration with our [React application](ht
 
 ### Resources
 
-#### `/api/auth`
+#### Auth
 
 route | methods | description | Docs
 :--- | :---: | :--- | :---:
@@ -46,11 +46,11 @@ route | methods | description | Docs
 
 ----
 
-#### `/api/users`
+#### Users
 
 route | methods | description | Docs
 :--- | :---: | :--- | :---:
-`api/users/:id` | DELETE | Deletes a specific user based on the ID parameter| [JS Doc](https://github.com/labs12-training-bot-2/labs-12-training-bot-2-BE/blob/master/controllers/user.js#L7-L31) |
+`api/users/:id` | DELETE | Deletes a specific user based on the ID parameter| [JS Doc](https://github.com/labs12-training-bot-2/labs12-training-bot-2-BE/blob/master/controllers/user.js#L7-L31) |
 
 ----
 
@@ -58,9 +58,9 @@ route | methods | description | Docs
 
 route | methods | description | Docs
 :--- | :---: | :--- | :---:
-`api/team-members/` | GET, POST | Get all Team Members associated with an authenticated User and/or Create a new Team Member associated with an authenticated User | [JS Doc](https://github.com/labs12-training-bot-2/labs-12-training-bot-2-BE/blob/master/controllers/teamMember.js#L16-L55) |
-`api/team-members/:id` | GET, PUT, DELETE | Read, Update, and Delete specific Team Members | [JS Doc](https://github.com/labs12-training-bot-2/labs-12-training-bot-2-BE/blob/master/controllers/teamMember.js#L57-L141) |
-`api/team-members/:id/unassign/:ts_id` | DELETE | Unassign a specified Team Member from a Training Series | [JS Doc](https://github.com/labs12-training-bot-2/labs-12-training-bot-2-BE/blob/master/controllers/teamMember.js#L143-L211) |
+`api/team-members/` | GET, POST | Get all Team Members associated with an authenticated User and/or Create a new Team Member associated with an authenticated User | [JS Doc](https://github.com/labs12-training-bot-2/labs12-training-bot-2-BE/blob/master/controllers/teamMember.js#L16-L55) |
+`api/team-members/:id` | GET, PUT, DELETE | Read, Update, and Delete specific Team Members | [JS Doc](https://github.com/labs12-training-bot-2/labs12-training-bot-2-BE/blob/master/controllers/teamMember.js#L57-L141) |
+`api/team-members/:id/unassign/:ts_id` | DELETE | Unassign a specified Team Member from a Training Series | [JS Doc](https://github.com/labs12-training-bot-2/labs12-training-bot-2-BE/blob/master/controllers/teamMember.js#L143-L211) |
 
 ----
 


### PR DESCRIPTION
# Description

There was a typo in the JS Doc URL's that prevented them from working as expected. This fixes that issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Tested locally and verified to be working

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
