### PR TITLE
:bug: Adjusts the malformed recipient_id migration

### DIFF
--- a/controllers/message.js
+++ b/controllers/message.js
@@ -22,11 +22,11 @@ router
      * @returns {Object} - The Express response object
      */
 
-    // Destructure the authenticated User from res.locals
-    const { user } = res.locals;
+    // Destructure the authenticated User email from res.locals
+    const { email } = res.locals.user;
 
     // Get all Messages from the database that are associated with the authenticated user
-    const messages = await Messages.find({ "u.email": user.email });
+    const messages = await Messages.find({ "u.email": email });
 
     // Return the found Messages to the client
     res.status(200).json({ messages });
@@ -42,13 +42,13 @@ router
      * @returns {Object} - The Express response object
      */
 
-    // Destructure the authenticated User from res.locals
-    const { user } = res.locals;
+    // Destructure the authenticated User email from res.locals
+    const { email } = res.locals.user;
 
     // Retrieve the Training Series referenced with the authenticated user by the training_series_id
     const trainingSeriesExists = await TrainingSeries.find({
       "ts.id": req.body.training_series_id,
-      "u.email": user.email
+      "u.email": email
     }).first();
 
     // If trainingSeriesExists is falsey, we can assume the Training Series does not exist
@@ -80,13 +80,13 @@ router
     // Destructure the Message ID from the request parameters
     const { id } = req.params;
 
-    // Destructure the authenticated user off of res.locals
-    const { user } = res.locals;
+    // Destructure the authenticated User email off of res.locals
+    const { email } = res.locals.user;
 
     // Get the Message associated with the user by ID
     const message = await Messages.find({
       "m.id": id,
-      "u.email": user.email
+      "u.email": email
     }).first();
 
     message
@@ -110,13 +110,13 @@ router
     // Destructure the ID off the request parameters
     const { id } = req.params;
 
-    // Destructure the authenticated User from res.locals
-    const { user } = res.locals;
+    // Destructure the authenticated User email from res.locals
+    const { email } = res.locals.user;
 
     // Attempt to find the Message in the database that relates to the authenticated user
     const messageExists = await Messages.find({
       "m.id": id,
-      "u.email": user.email
+      "u.email": email
     });
 
     // If messageExists is falsey, either the Message does not exist in the database or the authenticated user does not have access to it
@@ -143,7 +143,7 @@ router
     // Destructure the Message ID from the request parameters
     const { id } = req.params;
 
-    // Destructure the authenticated user off of res.locals
+    // Destructure the authenticated User email off of res.locals
     const { email } = res.locals.user;
 
     // Get the Message associated with the user by ID

--- a/controllers/notification.js
+++ b/controllers/notification.js
@@ -24,11 +24,11 @@ router
      * @returns {Object} - The Express response object
      */
 
-    // Destructure the authenticated user from res.locals
-    const { user } = res.locals;
+    // Destructure the authenticated User email from res.locals
+    const { email } = res.locals.user;
 
     // Get all Notifications from the database that are associated with the authenticated user
-    const notifications = await Notifications.find({ "u.email": user.email });
+    const notifications = await Notifications.find({ "u.email": email });
 
     // Return the found Notifications to the client
     res.status(200).json({ notifications });
@@ -44,8 +44,8 @@ router
      * @returns {Object} - The Express response object
      */
 
-    // Destructure the authenticated user from res.locals
-    const { user } = res.locals;
+    // Destructure the authenticated User email from res.locals
+    const { email } = res.locals.user;
 
     // Destructure the Message ID and Team Member ID off the request body
     const { message_id, team_member_id } = req.body;
@@ -53,7 +53,7 @@ router
     // Retrieve the Message referenced with the authenticated user by the message_id
     const messageExists = await Messages.find({
       "m.id": message_id,
-      "u.email": user.email
+      "u.email": email
     });
 
     // If messageExists is falsey, we can assume the Message does not exist
@@ -92,7 +92,7 @@ router.route("/:id").get(async (req, res) => {
   // Destructure the Notification ID from the request parameters
   const { id } = req.params;
 
-  // Destructure the authenticated user off of res.locals
+  // Destructure the authenticated User email off of res.locals
   const { email } = res.locals.user;
 
   // Attempt to find the Notification in the database that relates to the authenticated user
@@ -121,7 +121,7 @@ router.route("/:id/responses").get(async (req, res) => {
   // Destructure the Notification ID from the request parameters
   const { id } = req.params;
 
-  // Destructure the authenticated user off of res.locals
+  // Destructure the authenticated User email off of res.locals
   const { email } = res.locals.user;
 
   // Attempt to find the Notification in the database that relates to the authenticated user

--- a/controllers/teamMember.js
+++ b/controllers/teamMember.js
@@ -25,12 +25,12 @@ router
      * @returns {Object} - The Express response object
      */
 
-    // Destructure the authenticated User off of res.locals
-    const { user } = res.locals;
+    // Destructure the authenticated User email off of res.locals
+    const { email } = res.locals.user;
 
     // Get all Team Members from the database that are associated with the authenticated User
     const teamMembers = await TeamMember.find({
-      "u.email": user.email
+      "u.email": email
     });
 
     // Return the found Team Members to client
@@ -70,13 +70,13 @@ router
     // Destructure the ID off of the request parameters
     const { id } = req.params;
 
-    // Destructure the authenticated User off of res.locals
-    const { user } = res.locals;
+    // Destructure the authenticated User email off of res.locals
+    const { email } = res.locals.user;
 
     // Get the Team Member associated with a user by ID
     const teamMember = await TeamMember.find({
       "tm.id": id,
-      "u.email": user.email
+      "u.email": email
     }).first();
 
     // If teamMember is falsey, we can assume that Team Member doesn't exist

--- a/controllers/trainingSeries.js
+++ b/controllers/trainingSeries.js
@@ -21,11 +21,11 @@ router
      * @param {Object} res - The Express response object
      * @returns {Object} - The Express response object
      */
-    // Destructure the authenticated User off of res.locals
-    const { user } = res.locals;
+    // Destructure the authenticated User email off of res.locals
+    const { email } = res.locals.user;
     // Get all training series from the database that are associated with the authenticated User
     const trainingSeries = await TrainingSeries.find({
-      "u.email": user.email
+      "u.email": email
     });
     // Return the found training series to client
     res.status(200).json({ trainingSeries });

--- a/models/migrations/20190521131026_add_recipient_id.js
+++ b/models/migrations/20190521131026_add_recipient_id.js
@@ -1,6 +1,12 @@
 exports.up = function(knex, Promise) {
   return knex.schema.table("notifications", tbl => {
-    tbl.integer("recipient_id").notNullable();
+    tbl
+      .integer("recipient_id")
+      .references("id")
+      .inTable("team_members")
+      .onDelete("CASCADE")
+      .onUpdate("CASCADE")
+      .notNullable();
   });
 };
 


### PR DESCRIPTION
# Description

The first version of the recipient_id was done incorrectly as it should be a foreign key pointing to a team_members.id. This PR fixes that. WILL REQUIRE A MIGRATE:ROLLBACK >> MIGRATE:LATEST 

Also normalizes the destructuring of email off res.locals.user in all files to fix bug and ensure consistency

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

locally within psql -- as stated in description, will require rolling back of all migrations then running migrate:latest (and seed:run) in order to function as expected

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
