### PR TITLE
:bug: Updates notifications for recipient

### DIFF
--- a/controllers/notification.js
+++ b/controllers/notification.js
@@ -48,7 +48,7 @@ router
     const { email } = res.locals.user;
 
     // Destructure the Message ID and Team Member ID off the request body
-    const { message_id, team_member_id } = req.body;
+    const { message_id, team_member_id, recipient_id } = req.body;
 
     // Retrieve the Message referenced with the authenticated user by the message_id
     const messageExists = await Messages.find({
@@ -67,9 +67,17 @@ router
       "u.email": email
     });
 
-    // If teamMemberExists is falsey, we can assume the Team Member does not exist
-    if (!teamMemberExists) {
-      return res.status(404).json({ message: "That message does not exist." });
+    // Retrieve the Team Member referenced with the authenticated user by the recipient_id
+    const recipientExists = await TeamMembers.find({
+      "tm.id": team_member_id,
+      "u.email": email
+    });
+
+    // If teamMemberExists or recipientExists is falsey, we can assume one or both do not exist
+    if (!teamMemberExists || !recipientExists) {
+      return res
+        .status(404)
+        .json({ message: "One of those Team Members does not exist." });
     }
 
     // Add new Notification to the database

--- a/controllers/notification.js
+++ b/controllers/notification.js
@@ -69,7 +69,7 @@ router
 
     // Retrieve the Team Member referenced with the authenticated user by the recipient_id
     const recipientExists = await TeamMembers.find({
-      "tm.id": team_member_id,
+      "tm.id": recipient_id,
       "u.email": email
     });
 

--- a/controllers/teamMember.js
+++ b/controllers/teamMember.js
@@ -159,8 +159,7 @@ router.delete("/:id/unassign/:ts_id", async (req, res) => {
 
   // Find all Messages associated with the specified Training Series
   const messages = await Messages.find({
-    "ts.id": ts_id,
-    "m.for_team_member": true
+    "ts.id": ts_id
   });
 
   // If messages.length is falsey, we can assume that that Team Member hasn't

--- a/models/db/notifications.js
+++ b/models/db/notifications.js
@@ -38,9 +38,9 @@ function find(filters) {
       "n.thread",
       "n.message_id",
       "n.recipient_id",
+      "n.team_member_id",
       "ts.id AS training_series_id",
       "ts.title AS series",
-      "tm.id AS team_member_id",
       "tm.first_name",
       "tm.last_name",
       "tm.email",
@@ -54,7 +54,7 @@ function find(filters) {
     )
     .leftJoin("messages AS m", { "m.id": "n.message_id" })
     .leftJoin("services AS s", { "s.id": "n.service_id" })
-    .leftJoin("team_members AS tm", { "tm.id": "n.team_member_id" })
+    .leftJoin("team_members AS tm", { "tm.id": "n.recipient_id" })
     .leftJoin("users AS u", { "u.id": "tm.user_id" })
     .leftJoin("training_series AS ts", { "ts.id": "m.training_series_id" })
     .where(filters)


### PR DESCRIPTION
# Description

This PR fixed the issue where unassigning a team member from a series only deleted the notifications made from a message where for_team_member -- it did not delete notifications that were being sent only to a manager or mentor, but originated when the team member was being assigned.

Also adds an extra 404 check when creating a Message to see if the recipient exists or not as well as the team member. Adjusts notification.find() to retrieve info based on recipient_id instead of team_member_id.

Allows for filtering of notifications on the front end to show recipient info and be displayed on the proper team member page.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

locally in browser
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
