### PR TITLE
:sparkles: Reintroducing getAllResponses endpoint

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -136,10 +136,11 @@ Valid JWTs are provided by the Auth0 integration with our [React application](ht
 
 | route | methods | description | Docs |
 |:--- | :---: | :--- | :---:|
-| `api/responses/:id` | GET, DELETE | Get or delete specific Response | [JS Doc](https://github.com/labs12-training-bot-2/labs12-training-bot-2-BE/blob/master/controllers/responses.js#L22-L71) |
-| `api/responses/email` | POST | Create a new email Response | [JS Doc](https://github.com/labs12-training-bot-2/labs12-training-bot-2-BE/blob/master/controllers/responses.js#L73-L139)  |
-| `api/responses/sms` | POST | Create a new text Response | [JS Doc](https://github.com/labs12-training-bot-2/labs12-training-bot-2-BE/blob/master/controllers/responses.js#L141-L192)  |
-| `api/responses/slack` | POST | Create a new Slack Response | [JS Doc](https://github.com/labs12-training-bot-2/labs12-training-bot-2-BE/blob/master/controllers/responses.js#L194-L244)  |
+| `api/responses` | GET | Get all Responses for authenticated User | [JS Doc](https://github.com/labs12-training-bot-2/labs12-training-bot-2-BE/blob/master/controllers/responses.js#L22-L40) |
+| `api/responses/:id` | GET, DELETE | Get or delete specific Response | [JS Doc](https://github.com/labs12-training-bot-2/labs12-training-bot-2-BE/blob/master/controllers/responses.js#L42-L91) |
+| `api/responses/email` | POST | Create a new email Response | [JS Doc](https://github.com/labs12-training-bot-2/labs12-training-bot-2-BE/blob/master/controllers/responses.js#L93-L159)  |
+| `api/responses/sms` | POST | Create a new text Response | [JS Doc](https://github.com/labs12-training-bot-2/labs12-training-bot-2-BE/blob/master/controllers/responses.js#L161-L212)  |
+| `api/responses/slack` | POST | Create a new Slack Response | [JS Doc](https://github.com/labs12-training-bot-2/labs12-training-bot-2-BE/blob/master/controllers/responses.js#L214-L264)  |
 
 ---
 

--- a/controllers/responses.js
+++ b/controllers/responses.js
@@ -19,6 +19,26 @@ const Notifications = require("../models/db/notifications");
 const { authentication } = require("../middleware/authentication");
 const verifySlackToken = require("../middleware/verifySlackToken");
 
+router.route(authentication, "/").get(async (req, res) => {
+  /**
+   *Get all Responses for authenticated user
+   *
+   * @function
+   * @param {Object} req - The Express request object
+   * @param {Object} res - The Express response object
+   * @returns {Object} - The Express response object
+   */
+
+  // Destructure the authenticated User email from res.locals
+  const { email } = res.locals.user;
+
+  // Retrieve all Responses from the database for the authenticated User
+  const responses = await Responses.find({ "u.email": email });
+
+  // Return Responses to the client
+  res.status(200).json({ responses });
+});
+
 router
   .route(authentication, "/:id")
   .get(async (req, res) => {


### PR DESCRIPTION

# Description

GET /api/responses had oreviously been deleted due to mistakenly thinking it was not being used in FE. This PR brings it back, adds documentation, and updates the readme.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

locally in Postman

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
